### PR TITLE
SJ-11 and SJ-13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.zone5cloud</groupId>
   			<artifactId>z5-sdk-java-core</artifactId>
-  			<version>1.3.1</version>
+  			<version>1.3.2</version>
 		</dependency>
 
 		<dependency>

--- a/src-test/com/zone5cloud/http/core/TestThirdPartyConnections.java
+++ b/src-test/com/zone5cloud/http/core/TestThirdPartyConnections.java
@@ -83,6 +83,16 @@ public class TestThirdPartyConnections extends BaseTest {
 		
 		assertFalse(response.getResult().getIsUpgradeAvailable());
 		
+		// Now do it again but set the client agent such that getDeprecated will return true
+		Z5HttpClient.get().setUserAgent("ride-iOS/1.2.3 (10)");
+		
+		response = api.getDeprecated().get();
+		assertTrue(response.getStatusCode() >= 200 && response.getStatusCode() < 300);
+		assertNull(response.getError());
+		assertNotNull(response.getResult());
+		
+		assertTrue(response.getResult().getIsUpgradeAvailable());
+		
 	}
 	
 

--- a/src-test/com/zone5cloud/http/core/TestUsersAPI.java
+++ b/src-test/com/zone5cloud/http/core/TestUsersAPI.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -71,6 +72,7 @@ public class TestUsersAPI extends BaseTest {
 		User user = api.register(register).get().getResult();
 		assertNotNull(user.getId()); // our unique userId
 		assertEquals(email, user.getEmail());
+		assertEquals(Locale.getDefault().toString(), user.getLocale());
 		
 		// Note - in S-Digital, the user will need to validate their email before they can login...
 		if (api.getClient().isSpecialized()) {
@@ -116,9 +118,11 @@ public class TestUsersAPI extends BaseTest {
 		api.getClient().setToken(r.getToken());
 		
 		// Exercise the refresh access token
-		OAuthTokenAlt alt = api.refreshToken().get().getResult();
-		assertNotNull(alt.getToken());
-		assertNotNull(alt.getTokenExp());
+		if (api.getClient().isSpecialized()) {
+			OAuthTokenAlt alt = api.refreshToken().get().getResult();
+			assertNotNull(alt.getToken());
+			assertNotNull(alt.getTokenExp());
+		}
 		
 		// S-Digital Needs to be deleted via GIGYA
 		if (!api.getClient().isSpecialized()) {

--- a/src/com/zone5cloud/http/core/Z5HttpClient.java
+++ b/src/com/zone5cloud/http/core/Z5HttpClient.java
@@ -49,6 +49,7 @@ public class Z5HttpClient implements Closeable {
 	private String protocol = "https";
 	
 	private String bearer = null;
+	private String userAgent = null;
 	private ILogger logger = null;
 	
 	// this is a threadsafe client
@@ -103,6 +104,16 @@ public class Z5HttpClient implements Closeable {
 		return this.bearer;
 	}
 	
+	/** Set a user-agent string */
+	public void setUserAgent(String agent) {
+		this.userAgent = agent;
+	}
+	
+	/** Get the user's OAuth bearer token - note that this will include the Bearer prefix */
+	public String getUserAgent() {
+		return this.userAgent;
+	}
+	
 	/** Set an alternate logger */
 	public void setLogger(ILogger logger) {
 		this.logger = logger;
@@ -118,12 +129,22 @@ public class Z5HttpClient implements Closeable {
 			this.protocol = "https";
 	}
 	
-	/** Add authorization header, and also set the legacy tp-nodecorate header */
+	/**
+	 * Add headers: 
+	 * * add authorization header
+	 * * add the legacy tp-nodecorate header 
+	 * * add the customisable User-Agent header if set
+	 **/
 	protected void decorate(Z5HttpRequest<?> req) {
-		if (bearer != null)
-			req.addHeader("Authorization", bearer);
+		String token = this.bearer;
+		if (token != null)
+			req.addHeader("Authorization", token);
 		
 		req.addHeader("tp-nodecorate", "true");
+		
+		String agent = this.userAgent;
+		if (agent != null && !agent.isEmpty())
+			req.addHeader("User-Agent", agent);
 	}
 	
 	/** 

--- a/src/com/zone5cloud/http/core/api/ThirdPartyConnectionsAPI.java
+++ b/src/com/zone5cloud/http/core/api/ThirdPartyConnectionsAPI.java
@@ -93,14 +93,14 @@ public class ThirdPartyConnectionsAPI extends AbstractAPI {
 	}
 	
 	/**
-	 * Query whether an upgrade is available for the current user agent (client app).
+	 * Query whether the current version of the user agent (client app) has been deprecated and requires an upgrade.
 	 */
 	public Future<Z5HttpResponse<UpgradeAvailableResponse>> getDeprecated() {
 		return getDeprecated(null);
 	}
 	
 	/**
-	 * Query whether an upgrade is available for the current user agent (client app).
+	 * Query whether the current version of the user agent (client app) has been deprecated and requires an upgrade.
 	 * @param handler: callback on asynchronous completion
 	 */
 	public Future<Z5HttpResponse<UpgradeAvailableResponse>> getDeprecated(Z5HttpResponseHandler<UpgradeAvailableResponse> handler) {


### PR DESCRIPTION
* Pull in core 1.3.1 which sets default locale of new registered user to the OS's default locale.
* Add get/setUserAgent to Z5HttpClient to optionally set a customisable User-Agent header.